### PR TITLE
Remove @-ms-viewport

### DIFF
--- a/src/css/less/bootstrap/responsive-utilities.less
+++ b/src/css/less/bootstrap/responsive-utilities.less
@@ -17,11 +17,6 @@
 // Docs: http://getbootstrap.com/getting-started/#browsers
 // Source: http://timkadlec.com/2012/10/ie10-snap-mode-and-responsive-design/
 
-@-ms-viewport {
-  width: device-width;
-}
-
-
 // Visibility utilities
 .visible-xs,
 .visible-sm,


### PR DESCRIPTION
Not needed, usually defined in the head of the document.